### PR TITLE
Add a tarpit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.36.0-slim
 
 WORKDIR /app
-
+RUN rustup toolchain install nightly && rustup default nightly
 # For faster builds only refetch when Cargo.toml or Cargo.lock changes
 # cargo fetch needs a main file before it can run, so we stub one
 RUN mkdir /app/src

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,61 +1,94 @@
+#![feature(drain_filter)]
 #[macro_use]
 extern crate bitflags;
 
+use std::collections::LinkedList;
 use std::io::{self, Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::time::{Duration, Instant};
 
 mod epoll;
 
 const TEAPOT: &[u8] = b"HTTP/1.1 418 I'm a teapot\r\n\r\n";
 
-// Use a listen syscall and handle connections in a threadpool
+struct Tar<'run> {
+    start: Instant,
+    sock: &'run TcpStream,
+}
+
 fn main() {
-    // backlog is 128 by default
+    // setup listen with backlog of 128
     let listener = TcpListener::bind("0.0.0.0:8080").unwrap();
     listener
         .set_nonblocking(true)
         .expect("Unable to set nonblocking on listener");
     println!("Teapot starting on port 8080");
 
-    // use epoll_create and pass it to listener
+    // create an epoll data structure
     let epfd = match epoll::create() {
         Ok(epfd) => epfd,
         Err(e) => panic!(e),
     };
-    let mut event = epoll::Event::new(
-        epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
-        listener.as_raw_fd() as u64,
-    );
+    // setup events on listener fd
     epoll::ctl(
         epfd,
         epoll::ControlOptions::EPOLL_CTL_ADD,
         listener.as_raw_fd(),
-        event,
+        epoll::Event::new(
+            epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+            listener.as_raw_fd() as u64,
+        ),
     );
     run(&listener, epfd);
 }
 
 fn run(listener: &TcpListener, epfd: RawFd) {
+    let mut tarpit: LinkedList<Tar> = LinkedList::new();
+    println!("running");
     for stream in listener.incoming() {
-        let mut stream = match stream {
+        let stream = match stream {
             Ok(s) => s,
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                // epoll wait
+                // epoll wait, no conn attempted
                 let mut events: [epoll::Event; 32] = Default::default();
-                let nfds = match epoll::wait(epfd, &mut events, 10000) {
+                match epoll::wait(epfd, &mut events, 10000) {
                     Ok(nfds) => nfds,
                     Err(e) => panic!(e),
                 };
+                // attempt to empty tarpit
+                tarpit.drain_filter(|tar| {
+                    if Instant::now() - tar.start > Duration::new(10000, 0) {
+                        println!("draining from tarpit after epoll timeout");
+                        send_teapot(tar.sock);
+                        return true;
+                    }
+                    return false;
+                });
                 continue;
             }
             Err(e) => panic!(e),
         };
+        println!("stream is ready");
         stream
             .set_nonblocking(true)
             .expect("could not set stream nonblocking");
 
-        send_teapot(&stream);
+        // enqueue stream
+        tarpit.push_back(Tar {
+            start: Instant::now(),
+            sock: &stream,
+        });
+
+        // drain tarpit
+        tarpit.drain_filter(|tar| {
+            if Instant::now() - tar.start > Duration::new(10000, 0) {
+                println!("draining from tarpit after conn open");
+                send_teapot(tar.sock);
+                return true;
+            }
+            return false;
+        });
     }
 }
 


### PR DESCRIPTION
Use a linkedlist for O(1) removals and additions.

how tf do lifetimes work

after epoll unblocks or times out, we need to check the tarpit and release, respond, and close any connections who have been open for longer than 10s

should I use a [timerfd](http://man7.org/linux/man-pages/man2/timerfd_create.2.html) instead of a linkedlist?

closes #9 